### PR TITLE
Add Test for Broken Article Scrape

### DIFF
--- a/.github/workflows/test-daily.yaml
+++ b/.github/workflows/test-daily.yaml
@@ -1,0 +1,19 @@
+name: Test Daily
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Run Tests
+        run: npm test

--- a/src/scrape/scrapeAllIndividualArticles.ts
+++ b/src/scrape/scrapeAllIndividualArticles.ts
@@ -29,7 +29,16 @@ export async function scrapeAllIndividualArticles() {
   let i = 0;
   for (const { tag_name } of articles) {
     try {
-      await scrapeSingleArticleInfo(tag_name);
+      const { reading, header, mainText } = await scrapeSingleArticleInfo(tag_name);
+      await prisma.pixivArticle.update({
+        where: { tag_name },
+        data: {
+          lastScrapedArticle: Date.now().toString(),
+          reading,
+          header: JSON.stringify(header),
+          mainText,
+        },
+      });
     } catch (error) {
       console.error(`Error scraping article ${tag_name}: ${error}`);
     }

--- a/src/scrape/scrapeSingleArticleInfo.ts
+++ b/src/scrape/scrapeSingleArticleInfo.ts
@@ -1,6 +1,5 @@
 import { JSDOM } from 'jsdom';
 import { fetchURL } from '../fetch/fetchURL';
-import { prisma } from '..';
 import { PIXIV_BASE_URL } from '../constants';
 const pixivArticleURL = (tag_name: string) =>
   `${PIXIV_BASE_URL}a/${encodeURIComponent(tag_name)}`;
@@ -15,16 +14,11 @@ export async function scrapeSingleArticleInfo(tag_name: string) {
   const header = getHeaders(document);
   const mainText = getMainText(document);
 
-  // Update the article
-  await prisma.pixivArticle.update({
-    where: { tag_name },
-    data: {
-      lastScrapedArticle: Date.now().toString(),
-      reading,
-      header: JSON.stringify(header),
-      mainText,
-    },
-  });
+  return {
+    reading,
+    header,
+    mainText,
+  };
 }
 
 function getHeaders(document: Document) {

--- a/test/scrapeSingleArticleInfo.test.ts
+++ b/test/scrapeSingleArticleInfo.test.ts
@@ -1,0 +1,14 @@
+import test from 'ava';
+import { scrapeSingleArticleInfo } from '../src/scrape/scrapeSingleArticleInfo';
+
+test('scrapeSingleArticleInfo should not return null values for フリーレン', async (t) => {
+  const frierenTag = 'フリーレン';
+  const { reading, header, mainText } =
+    await scrapeSingleArticleInfo(frierenTag);
+
+  t.truthy(reading, 'Reading should not be null or empty');
+  t.truthy(mainText, 'MainText should not be null or empty');
+
+  t.true(Array.isArray(header), 'Header should be a valid JSON array');
+  t.true(header.length > 0, 'Header array should have length greater than 0');
+});


### PR DESCRIPTION
Resolves #12

Add test for broken article scrape and separate DB update logic

* Adds a new test file `test/scrapeSingleArticleInfo.test.ts` to check if `reading`, `header`, or `mainText` are null for the article `https://dic.pixiv.net/a/フリーレン`.
* Adds a new workflow file `.github/workflows/test-daily.yaml` to run the test once daily.