### PR TITLE
Separate newly never-scraped and updated articles scraping articles

### DIFF
--- a/src/scrape/scrapeAllIndividualArticles.ts
+++ b/src/scrape/scrapeAllIndividualArticles.ts
@@ -13,21 +13,33 @@ export async function scrapeAllIndividualArticles() {
   // 1. Articles never scraped individually (lastScrapedArticle IS NULL) - prioritized first
   // 2. Articles updated since last individual scrape (lastScraped > lastScrapedArticle)
   // We need to use queryRaw because these fields are saved as strings of numbers.
-  const articles = await prisma.$queryRaw<Array<{ tag_name: string }>>`
+
+  // Newly never-scraped articles (lastScrapedArticle IS NULL)
+  const newlyNeverScraped = await prisma.$queryRaw<Array<{ tag_name: string }>>`
     SELECT tag_name
     FROM PixivArticle
     WHERE lastScrapedArticle IS NULL
-      OR (
-        lastScraped IS NOT NULL
-        AND lastScrapedArticle IS NOT NULL
-        AND lastScraped GLOB '[0-9]*'
-        AND lastScrapedArticle GLOB '[0-9]*'
-        AND CAST(lastScraped AS INTEGER) > CAST(lastScrapedArticle AS INTEGER)
-      )
-    ORDER BY lastScrapedArticle IS NULL DESC, tag_name
+    ORDER BY CAST(lastScraped as INTEGER) ASC,
   `;
 
-  console.log(`Scraping ${articles.length} individual articles`);
+  // Updated articles (lastScrapedArticle IS NOT NULL and lastScraped > lastScrapedArticle)
+  const updatedArticles = await prisma.$queryRaw<Array<{ tag_name: string }>>`
+    SELECT tag_name
+    FROM PixivArticle
+    WHERE lastScrapedArticle IS NOT NULL
+      AND lastScraped IS NOT NULL
+      AND lastScraped GLOB '[0-9]*'
+      AND lastScrapedArticle GLOB '[0-9]*'
+      AND CAST(lastScraped AS INTEGER) > CAST(lastScrapedArticle AS INTEGER)
+    ORDER BY CAST(lastScraped AS INTEGER) ASC,
+             tag_name
+  `;
+
+  const articles = [...newlyNeverScraped, ...updatedArticles];
+
+  console.log(
+    `Scraping ${articles.length} individual articles (${newlyNeverScraped.length} newly added, ${updatedArticles.length} updated)`,
+  );
 
   const progressBar = new cliProgress.SingleBar(
     {
@@ -69,6 +81,9 @@ export async function scrapeAllIndividualArticles() {
     progressBar.update(progressBarIndex);
     if (progressBarIndex % 1000 === 0) {
       console.log(`Processed ${progressBarIndex} articles`);
+    }
+    if (progressBarIndex === newlyNeverScraped.length) {
+      console.log(`All newly added articles processed`);
     }
   }
   progressBar.stop();

--- a/src/scrape/scrapeAllIndividualArticles.ts
+++ b/src/scrape/scrapeAllIndividualArticles.ts
@@ -19,7 +19,7 @@ export async function scrapeAllIndividualArticles() {
     SELECT tag_name
     FROM PixivArticle
     WHERE lastScrapedArticle IS NULL
-    ORDER BY CAST(lastScraped as INTEGER) ASC,
+    ORDER BY CAST(lastScraped as INTEGER) ASC
   `;
 
   // Updated articles (lastScrapedArticle IS NOT NULL and lastScraped > lastScrapedArticle)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scraping logs now show a detailed breakdown: total articles, how many are newly added, and how many are updates.
  * Added a milestone log indicating when all newly added articles have been processed.

* **Refactor**
  * Reworked scraping to process newly added articles first, then updated ones, improving clarity and perceived responsiveness.
  * Consolidated results into a single processing list while maintaining prioritized order for a smoother scraping workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->