### PR TITLE
Fix reading extraction for Pixiv article scraping

### DIFF
--- a/src/scrape/scrapeSingleArticleInfo.ts
+++ b/src/scrape/scrapeSingleArticleInfo.ts
@@ -54,11 +54,14 @@ function getHeaders(document: Document, tag_name: string): string[] {
 }
 
 function getReading(document: Document) {
-  return (
-    document
-      .getElementById('article-content-header')
-      ?.querySelector('.my-4.text-text3.typography-12')?.textContent || ''
-  );
+  const header = document.getElementById('article-content-header');
+
+  const readingElement =
+    header?.querySelector('p.text-12.text-text3') ??
+    header?.querySelector('p.text-12') ??
+    header?.querySelector('p[class*=text-12]');
+
+  return readingElement?.textContent?.trim() ?? '';
 }
 
 function getMainText(document: Document): string {

--- a/src/test/scrapeSingleArticleInfo.test.ts
+++ b/src/test/scrapeSingleArticleInfo.test.ts
@@ -6,6 +6,13 @@ test('scrapeSingleArticleInfo should not return null values for フリーレン'
   const { reading, header, mainText } =
     await scrapeSingleArticleInfo(frierenTag);
 
+  console.log('scrapeSingleArticleInfo result', {
+    reading,
+    header,
+    mainTextLength: mainText?.length ?? 0,
+    mainTextSample: mainText?.slice(0, 200) ?? '',
+  });
+
   expect(reading).toBeTruthy();
   expect(mainText).toBeTruthy();
   expect(Array.isArray(header)).toBe(true);


### PR DESCRIPTION
## Summary
- update reading extraction to handle the current Pixiv article header markup
- trim the extracted reading text and provide class-based fallbacks for resilience

## Testing
- bun test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940ee888ea48333a63192b23685d653)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved article content extraction with additional fallback checks, resulting in more reliable content detection across varied page layouts.

* **Tests**
  * Added extra debug logging to tests to surface extracted content and length previews during test runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->